### PR TITLE
Refactor and maze algorithm

### DIFF
--- a/src/maze.py
+++ b/src/maze.py
@@ -123,21 +123,7 @@ class Cell:
             Point(center_x_source, center_y_source),
             Point(center_x_destination, center_y_destination),
         )
-
         self._window.draw_line(line, fill_color=line_color)
-
-    def get_wall_directions(self) -> Dict[str, Tuple[int, int, int, int]]:
-        """
-        Calculates the current connecting points for a wall based on the
-        current values of x1, y1, x2, y2 and maps each direction to its coordinates
-        """
-        wall_directions = {
-            "top": (self.x1, self.y1, self.x2, self.y1),
-            "right": (self.x2, self.y2, self.x2, self.y1),
-            "bottom": (self.x2, self.y2, self.x1, self.y2),
-            "left": (self.x1, self.y1, self.x1, self.y2),
-        }
-        return wall_directions
 
 
 class Maze:
@@ -148,8 +134,8 @@ class Maze:
     -----
     x_start : int : Represents how many pixels from the left the maze runner should start
     x_start : int : Represents how many pixels from the top the maze runner should start
-    num_cols : int : Total cell columns
     num_rows : int : Total cell rows
+    num_cols : int : Total cell columns
     cell_width : int : Cell width
     cell_height : int : Cell height
     cells : list[list[Cell]] : List of cells in the maze
@@ -167,8 +153,8 @@ class Maze:
         self,
         x_start: int,
         y_start: int,
-        num_cols: int,
         num_rows: int,
+        num_cols: int,
         cell_width: int,
         cell_height: int,
         seed=None,
@@ -183,8 +169,8 @@ class Maze:
             raise ValueError("Cell height must be greater than zero")
         self._x_start = x_start
         self._y_start = y_start
-        self._num_cols = num_cols
         self._num_rows = num_rows
+        self._num_cols = num_cols
         self._cell_width = cell_width
         self._cell_height = cell_height
         self._cells = []
@@ -239,70 +225,6 @@ class Maze:
             return self._cells[row][col]
         else:
             return None
-
-    # def _break_walls_r(self, row: int, col: int) -> None:
-    #     """
-    #     Breaks a wall between two cells in the maze
-    #     If cells[row][col] does not have right wall, cells[row][col+1] should not have left wall and so on...
-    #     """
-    #     adjacent_cells = {
-    #         "top": ((row - 1, col), "bottom"),
-    #         "right": ((row, col + 1), "left"),
-    #         "bottom": ((row + 1, col), "top"),
-    #         "left": ((row, col - 1), "right"),
-    #     }
-    #     current_cell: Cell = self.get_cell(row, col)
-    #     current_cell.visited = True
-    #     # print(f"Current cell: {repr(current_cell)}")
-
-    #     while True:
-    #         to_visit = []
-    #         for direction, value in adjacent_cells.items():
-    #             coords, opposite_wall = value
-    #             print(f"COORDES: {coords}\ncurrent coords: {row}, {col}\n++++++++++++")
-    #             neighbor_row, neighbor_col = coords
-
-    #             # Boundary check
-    #             if not (0 <= neighbor_row <= self.num_rows - 1) or not (
-    #                 0 <= neighbor_col <= self.num_cols - 1
-    #             ):
-    #                 print(f"%%%%%%%%\nBREAK: \nRow:{neighbor_row}\nCol: {neighbor_col}")
-    #                 continue
-
-    #             neighbor = self.get_cell(*coords)
-    #             if neighbor is not None and not neighbor.visited:
-    #                 print(f"Neighbor in for loop: {repr(neighbor.visited)}\n-------\n")
-    #                 to_visit.append(direction)
-    #             else:
-    #                 continue
-    #         print(f"TO VISIT: {to_visit}\n++++++++\n")
-    #         if not to_visit:
-    #             return
-
-    #         # random_index = random.randrange(len(to_visit))
-    #         # random_direction = random.choice(to_visit)
-    #         # print(random_direction)
-    #         random_idx = random.randrange(len(to_visit))
-    #         to_visit_wall = to_visit[random_idx]
-    #         coords, opposite_wall = adjacent_cells[to_visit_wall]
-    #         print(
-    #             f"######\nrandom wall: {to_visit_wall}\nNEW COORDS: {coords}\nOPPOSITE_WALL: {opposite_wall}\n#######"
-    #         )
-    #         # print(opposite_value, coords, opposite_wall, sep="\n:")
-    #         # print(repr(neighbor), repr(current_cell), sep="\n-----"
-    #         neighbor = self.get_cell(*coords)
-    #         print(
-    #             f"\n,,,,,,,,,,,,,,,\nneighbor before setting walls: {repr(neighbor)}\nCurrent cell: {repr(current_cell)}\n,,,,,,,,,,"
-    #         )
-    #         setattr(current_cell, f"has_{to_visit_wall}_wall", False)
-    #         setattr(neighbor, f"has_{opposite_wall}_wall", False)
-    #         # print(repr(neighbor), repr(current_cell), sep="\n-----")
-
-    #         print(
-    #             f"Neighbor outside for loop: {repr(neighbor)}\nCurrent cell: {repr(current_cell)}\n----------\n----------\nRECURSION\n------\n----------\n"
-    #         )
-    #         if not neighbor.visited:
-    #             self._break_walls_r(*coords)
 
 
 class MazeDrawer:
@@ -382,53 +304,21 @@ class MazeDrawer:
         }
         current_cell: Cell = self._maze.get_cell(row, col)
         current_cell.visited = True
-        # print(f"Current cell: {repr(current_cell)}")
+        random_directions = list(adjacent_cells.keys())
+        random.shuffle(random_directions)
 
-        while True:
-            to_visit = []
-            for direction, (coords, opposite_wall) in adjacent_cells.items():
-                print(f"COORDES: {coords}\ncurrent coords: {row}, {col}\n++++++++++++")
-                neighbor_row, neighbor_col = coords
+        for direction in random_directions:
+            coords, opposite_direction = adjacent_cells[direction]
+            neighbor_row, neighbor_col = coords
 
-                # Boundary check
-                if not (0 <= neighbor_row <= self._maze.num_rows - 1) or not (
-                    0 <= neighbor_col <= self._maze.num_cols - 1
-                ):
-                    print(f"%%%%%%%%\nBREAK: \nRow:{neighbor_row}\nCol: {neighbor_col}")
-                    continue
-
+            # Boundary check
+            if (0 <= neighbor_row < self._maze.num_rows) or (
+                0 <= neighbor_col < self._maze.num_cols
+            ):
                 neighbor = self._maze.get_cell(*coords)
-                if neighbor is not None and not neighbor.visited:
-                    print(f"Neighbor in for loop: {repr(neighbor.visited)}\n-------\n")
-                    to_visit.append(direction)
-                else:
-                    continue
-            print(f"TO VISIT: {to_visit}\n++++++++\n")
-            if not to_visit:
-                self._draw_cell(row, col)
-                return
-
-            # random_index = random.randrange(len(to_visit))
-            # random_direction = random.choice(to_visit)
-            # print(random_direction)
-            random_idx = random.randrange(len(to_visit))
-            to_visit_wall = to_visit[random_idx]
-            coords, opposite_wall = adjacent_cells[to_visit_wall]
-            print(
-                f"######\nrandom wall: {to_visit_wall}\nNEW COORDS: {coords}\nOPPOSITE_WALL: {opposite_wall}\n#######"
-            )
-            # print(opposite_value, coords, opposite_wall, sep="\n:")
-            # print(repr(neighbor), repr(current_cell), sep="\n-----"
-            neighbor = self._maze.get_cell(*coords)
-            print(
-                f"\n,,,,,,,,,,,,,,,\nneighbor before setting walls: {repr(neighbor)}\nCurrent cell: {repr(current_cell)}\n,,,,,,,,,,"
-            )
-            setattr(current_cell, f"has_{to_visit_wall}_wall", False)
-            setattr(neighbor, f"has_{opposite_wall}_wall", False)
-            # print(repr(neighbor), repr(current_cell), sep="\n-----")
-
-            print(
-                f"Neighbor outside for loop: {repr(neighbor)}\nCurrent cell: {repr(current_cell)}\n----------\n----------\nRECURSION\n------\n----------\n"
-            )
-            if not neighbor.visited:
-                self._break_walls_r(*coords)
+                if neighbor and not neighbor.visited:
+                    print(f"Neighbor in for loop: {repr(neighbor)}\n-------\n")
+                    setattr(current_cell, f"has_{direction}_wall", False)
+                    setattr(neighbor, f"has_{opposite_direction}_wall", False)
+                    self._break_walls_r(*coords)
+                    self._draw_cell(row, col)

--- a/src/maze.py
+++ b/src/maze.py
@@ -249,6 +249,12 @@ class Maze:
         else:
             return None
 
+    def reset_visited_cells(self):
+        """Sets all cells in matrix to unvisited"""
+        for col in range(self._num_cols):
+            for row in range(self._num_rows):
+                self._cells[col][row].visited = False
+
 
 class MazeDrawer:
     """
@@ -275,6 +281,7 @@ class MazeDrawer:
         self._create_cells()
         self._create_entrance_and_exit()
         self._break_walls_r(0, 0)
+        self._maze.reset_visited_cells()
 
 
     def _create_cells(self) -> None:
@@ -333,7 +340,7 @@ class MazeDrawer:
 
             # Boundary check
             if 0 <= neighbor_row <= self._maze.num_rows and 0 <= neighbor_col <= self._maze.num_cols:
-                neighbor = self._maze.get_cell(neighbor_col, neighbor_row, )
+                neighbor = self._maze.get_cell(neighbor_col, neighbor_row)
 
                 # If the neighbor hasn't been visited, break the walls and recurse
                 if neighbor and not neighbor.visited:

--- a/src/maze.py
+++ b/src/maze.py
@@ -160,7 +160,8 @@ class Maze:
         self._cell_width = cell_width
         self._cell_height = cell_height
         self._cells = []
-        self._seed = random.seed(4)
+        if seed is not None:
+            self._seed = random.seed(4)
 
     def __format__(self, format_spec):
         match format_spec:

--- a/src/maze.py
+++ b/src/maze.py
@@ -117,6 +117,13 @@ class Cell:
             point2 = wall_directions[direction][2:]
             wall_line = Line(Point(*point1), Point(*point2))
             self._window.draw_line(wall_line, fill_color)
+            # self._window.redraw()
+            # time.sleep(0.1)
+
+    # def _animate(self) -> None:
+    #     """Animates maze by drawing cells one at a time and allows us to visulize our algorithm"""
+    #     self._window.redraw()
+    #     time.sleep(0.1)
 
     def draw_move(self, to_cell: "Cell", undo=False) -> None:
         """
@@ -157,8 +164,8 @@ class Maze:
     -----
     x_start : int : Represents how many pixels from the left the maze runner should start
     x_start : int : Represents how many pixels from the top the maze runner should start
-    num_rows : int : Total cell rows
     num_cols : int : Total cell columns
+    num_rows : int : Total cell rows
     cell_width : int : Cell width
     cell_height : int : Cell height
     cells : list[list[Cell]] : List of cells in the maze
@@ -176,8 +183,8 @@ class Maze:
         self,
         x_start: int,
         y_start: int,
-        num_rows: int,
         num_cols: int,
+        num_rows: int,
         cell_width: int,
         cell_height: int,
         seed=None,
@@ -321,7 +328,7 @@ class MazeDrawer:
         top_cell.has_top_wall = False
         bottom_cell.has_bottom_wall = False
         top_cell.visited = True
-        bottom_cell.visited = True
+        
         self._draw_cell(0, 0)
         self._draw_cell(self._maze.num_cols - 1, self._maze.num_rows - 1)
 
@@ -337,9 +344,9 @@ class MazeDrawer:
             # Get the neighbor cell based on the direction
             neighbor_coords, opposite_direction = self._get_neighbor_coords(col, row, direction)
             neighbor_col, neighbor_row = neighbor_coords
-
+           
             # Boundary check
-            if 0 <= neighbor_row <= self._maze.num_rows and 0 <= neighbor_col <= self._maze.num_cols:
+            if 0 <= neighbor_row < self._maze.num_rows and 0 <= neighbor_col < self._maze.num_cols:
                 neighbor = self._maze.get_cell(neighbor_col, neighbor_row)
 
                 # If the neighbor hasn't been visited, break the walls and recurse

--- a/src/maze.py
+++ b/src/maze.py
@@ -40,7 +40,6 @@ class Cell:
         self.x2 = None
         self.y2 = None
         self.visited = False
-        self._fill_color = None
 
     def __repr__(self):
         return "\n------\n".join((
@@ -117,13 +116,6 @@ class Cell:
             point2 = wall_directions[direction][2:]
             wall_line = Line(Point(*point1), Point(*point2))
             self._window.draw_line(wall_line, fill_color)
-            # self._window.redraw()
-            # time.sleep(0.1)
-
-    # def _animate(self) -> None:
-    #     """Animates maze by drawing cells one at a time and allows us to visulize our algorithm"""
-    #     self._window.redraw()
-    #     time.sleep(0.1)
 
     def draw_move(self, to_cell: "Cell", undo=False) -> None:
         """
@@ -173,10 +165,8 @@ class Maze:
 
     Methods
     -----
-    init_cells -> None : Initializes the matrix of a maze
-    get_cell(i: int, j: int) -> Cell : Returns the cell at the specified row and column
-    break_walls_r(i : int, j : int) -> None : Animates depth-first traversal algorithm to create maze
-
+    init_cells -> None : Initializes the matrix with Cell objects
+    get_cell(col: int, row: int) -> Cell : Returns the cell at the specified column and row
     """
 
     def __init__(
@@ -250,7 +240,10 @@ class Maze:
         ]
 
     def get_cell(self, col: int, row: int) -> Cell | None:
-        """Returns the cell at the specified row and column."""
+        """
+        Returns the cell at the specified row and column.
+        Returns None if the cell is out of bounds.
+        """
         if 0 <= row < self._num_rows and 0 <= col < self._num_cols:
             return self._cells[col][row]
         else:
@@ -270,6 +263,7 @@ class MazeDrawer:
     Attributes
     -----
     maze : Maze
+    window : Window
 
     Methods:
     ----
@@ -278,6 +272,10 @@ class MazeDrawer:
     animate -> None : Animates maze by drawing cells one at a time and allows us to visulize our algorithm
     draw_entrance_and_exit -> None : Draws entrance and exit to maze by removing the top wall of the first cell and
     the bottom wall of the last cell
+    break_walls_r(col : int, row : int) -> None : Recursive backtracking algorithm to create maze
+    get_neighbor_coords(col: int, row: int, direction: str) -> Tuple[Tuple[int, int], str]
+        Returns the coordinates of the neighbor cell and the direction of the wall that connects them
+        
     """
 
     def __init__(self, maze: Maze, window: Window):
@@ -333,6 +331,10 @@ class MazeDrawer:
         self._draw_cell(self._maze.num_cols - 1, self._maze.num_rows - 1)
 
     def _break_walls_r(self, col: int, row: int) -> None:
+        """
+        Uses a depth-first approach to setting the walls of the maze.
+        This method is used to break the walls of the maze in a random order and set every cell to visited.
+        """
         current_cell: Cell = self._maze.get_cell(col, row)
         current_cell.visited = True
 
@@ -360,7 +362,17 @@ class MazeDrawer:
             self._draw_cell(col, row)
 
     def _get_neighbor_coords(self, col: int, row: int, direction: str) -> Tuple[Tuple[int, int], str]:
-        # Dictionary to map direction to neighbor coordinates and opposite wall
+        """
+        Dictionary to map direction to neighbor coordinates and opposite wall
+        -----
+        adjacent_cells = {
+            "top": ((col, row - 1, ), "bottom"),
+            "right": ((col + 1, row), "left"),
+            "bottom": ((col, row + 1), "top"),
+            "left": ((col - 1, row), "right"),
+        }
+        return adjacent_cells[direction]
+        """
         adjacent_cells = {
             "top": ((col, row - 1, ), "bottom"),
             "right": ((col + 1, row), "left"),

--- a/src/maze.py
+++ b/src/maze.py
@@ -319,24 +319,28 @@ class MazeDrawer:
         self._draw_cell(0, 0)
         self._draw_cell(self._maze.num_rows - 1, self._maze.num_cols - 1)
 
-    def _break_walls_r(self, row: int, col: int) -> None:
+    def _break_walls_r(self, *args) -> None:
         """
         Breaks a wall between two cells in the maze
         If cells[row][col] does not have right wall, cells[row][col+1] should not have left wall and so on...
         """
+        row, col, opposite_direction = args
         adjacent_cells = {
             "top": ((row - 1, col), "bottom"),
             "right": ((row, col + 1), "left"),
             "bottom": ((row + 1, col), "top"),
             "left": ((row, col - 1), "right"),
         }
+        to_visit = []
         current_cell: Cell = self._maze.get_cell(row, col)
         current_cell.visited = True
         random_directions = list(adjacent_cells.keys())
-        # random.shuffle(random_directions)
+        random.shuffle(random_directions)
+        direction = random_directions[0]
+        # random_i = random.randint(4)
+        to_visit.append(adjacent_cells[direction])
 
-        to_visit = []
-        for direction in random_directions:
+        while to_visit:
             coords, opposite_direction = adjacent_cells[direction]
             neighbor_row, neighbor_col = coords
 
@@ -345,7 +349,10 @@ class MazeDrawer:
                 0 <= neighbor_col < self._maze.num_cols
             ):
                 neighbor = self._maze.get_cell(*coords)
-                if neighbor and not neighbor.visited:            
+                if neighbor and not neighbor.visited: 
+                    to_visit.append((coords, opposite_direction))
+                    neighbor.visited = True
+           
                     has_wall_str = f"has_{direction}_wall"
                     has_opposite_wall_str = f"has_{opposite_direction}_wall"
                     has_wall = getattr(current_cell, has_wall_str)

--- a/src/screen.py
+++ b/src/screen.py
@@ -54,6 +54,7 @@ class Window:
     Methods
     -----
     wait_for_close -> None
+    draw_line(line : Line, fille_color ?: str) -> None : Draws line to canvas
     start() -> None
     close -> None
     redraw() -> None

--- a/src/screen.py
+++ b/src/screen.py
@@ -105,6 +105,10 @@ class Window:
         """
         Responsible for drawing a line on the canvas
         """
+        point1, point2 = line.point1, line.point2
+        x1, y1 = point1.x, point1.y
+        x2, y2 = point2.x, point2.y
+        # self._canvas.create_line(x1, y1, x2, y2, fill=fill_color, width=2)
         line.draw(self._canvas, fill_color)
 
     def wait_for_close(self) -> None:

--- a/src/screen.py
+++ b/src/screen.py
@@ -96,7 +96,6 @@ class Window:
         x1, y1 = point1.x, point1.y
         x2, y2 = point2.x, point2.y
         self._canvas.create_line(x1, y1, x2, y2, fill=fill_color, width=2)
-        # line.draw(self._canvas, fill_color)
 
     def wait_for_close(self) -> None:
         """Method that checks if window is still open before drawing to it"""

--- a/src/screen.py
+++ b/src/screen.py
@@ -53,12 +53,12 @@ class Window:
 
     Methods
     -----
-    wait_for_close -> None
+    wait_for_close -> None : calls self.redraw() if window still is valid
     draw_line(line : Line, fille_color ?: str) -> None : Draws line to canvas
-    start() -> None
-    close -> None
-    redraw() -> None
-    is_valid_window -> bool
+    start() -> None : starts mainloop for window to stay open
+    close -> None : terminates window
+    redraw() -> None : Updates window
+    is_valid_window -> bool : checks if window still exists
     """
 
     def __init__(self, width: int, height: int):

--- a/src/screen.py
+++ b/src/screen.py
@@ -28,32 +28,18 @@ class Line:
     -----
     point1 : Point
     point2 : Point
-
-    Methods
-    -----
-    draw(canvas : Tk.Canvas, fill_color ?: str) -> None
     """
 
     def __init__(self, point1: Point, point2: Point):
-        self.point1 = point1
-        self.point2 = point2
+        self.__point1 = point1
+        self.__point2 = point2
 
     def __repr__(self):
-        return f"Line(\n\t{repr(self.point1)},\n\t{repr(self.point2)}\n\t)"
+        return f"Line(\n\t{repr(self.__point1)},\n\t{repr(self.__point2)}\n\t)"
 
-    def draw(self, canvas: Canvas, fill_color: str = "black") -> None:
-        """Takes x and y positions of both points and draws a line between them"""
-        if (self.point1.x > self.point2.x and self.point1.y != self.point2.y) or (
-            self.point1.y > self.point2.y and self.point1.x != self.point2.x
-        ):
-            raise ValueError(f"Line cannot be drawn with invalid points: {repr(self)}")
-
-        x1 = self.point1.x
-        y1 = self.point1.y
-        x2 = self.point2.x
-        y2 = self.point2.y
-        canvas.create_line(x1, y1, x2, y2, fill=fill_color, width=2)
-        canvas.pack(fill=BOTH, expand=1)
+    def get_points(self) -> tuple[Point, Point]:
+        """Returns the two connecting points of a line"""
+        return self.__point1, self.__point2
 
 
 class Window:
@@ -105,11 +91,11 @@ class Window:
         """
         Responsible for drawing a line on the canvas
         """
-        point1, point2 = line.point1, line.point2
+        point1, point2 = line.get_points()
         x1, y1 = point1.x, point1.y
         x2, y2 = point2.x, point2.y
-        # self._canvas.create_line(x1, y1, x2, y2, fill=fill_color, width=2)
-        line.draw(self._canvas, fill_color)
+        self._canvas.create_line(x1, y1, x2, y2, fill=fill_color, width=2)
+        # line.draw(self._canvas, fill_color)
 
     def wait_for_close(self) -> None:
         """Method that checks if window is still open before drawing to it"""

--- a/tests/maze-tests.py
+++ b/tests/maze-tests.py
@@ -14,20 +14,19 @@ def mock_gui_with_setup(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         with mock.patch(
-            "src.screen.Window.start", lambda *args, **kwargs: None
+            "src.screen.Window.__init__",
+            lambda *args, **kwargs: None,
         ), mock.patch(
-            "src.screen.Window.draw_line", lambda *args, **kwargs: None
+            "src.maze.MazeDrawer._animate", lambda *args, **kwargs: None
         ), mock.patch(
-            "src.screen.Window.redraw", lambda *args, **kwargs: None
-        ), mock.patch(
-            "src.maze.MazeDrawer._create_cells"
+            "src.maze.Cell.draw_wall", lambda *args, **kwargs: None
         ):
             win = Window(800, 800)
             num_cols = 12
             num_rows = 10
-            m = Maze(0, 0, num_rows, num_cols, 10, 10)
-            m_gui = MazeDrawer(m, win)
-            kwargs.update({"win": win, "m": m, "m_drawer": m_gui})
+            m = Maze(0, 0, num_cols, num_rows, 10, 10)
+            MazeDrawer(m, win)
+            kwargs.update({"m": m})
 
             return func(*args, **kwargs)
 
@@ -39,7 +38,7 @@ class MazeTest(TestCase):
         win = Window(800, 800)
         num_cols = 12
         num_rows = 10
-        m = Maze(0, 0, num_rows, num_cols, 10, 10)
+        m = Maze(0, 0, num_cols, num_rows, 10, 10)
         m.init_cells(win)
         self.assertEqual(
             len(m._cells),
@@ -66,7 +65,7 @@ class MazeTest(TestCase):
             m = Maze(10, 10, 10, 10, 5, 0)
             m.cell_height
 
-    def test_maze_format(self):
+    def test_maze_format_str(self):
         num_cols = 12
         num_rows = 10
         cell_width = 10
@@ -78,16 +77,20 @@ class MazeTest(TestCase):
         )
 
     @mock_gui_with_setup
-    def test_maze_draw_entrance_and_exit(
-        self, win: Window, m: Maze, m_drawer: MazeDrawer
-    ):
+    def test_maze_draw_entrance_and_exit(self, m: Maze):
         top = m.get_cell(0, 0)
         bottom = m.get_cell(
-            m.num_rows - 1,
             m.num_cols - 1,
+            m.num_rows - 1,
         )
         self.assertEqual(top.has_top_wall, False)
         self.assertEqual(bottom.has_bottom_wall, False)
+
+    @mock_gui_with_setup
+    def test_reset_visited_cells(self, m: Maze):
+        for col in m._cells:
+            for cell in col:
+                self.assertEqual(cell.visited, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What was done
## Refactored draw methods
- Removed unnecessary draw methods from Window and Line to centralize drawing of line. There is now one method responsible for drawing to the canvas and it is in the Window
## Standardized how I expect coordinate parameters
- Refactored method signatures to adhere to x, y paradigm. gets cells from matrix like cell[col][row]:
```py
    def init_cells(self, win: Window) -> None:
        """Initializes the matrix of a maze"""
        self._cells = [
            [Cell(win) for _ in range(self._num_rows)] for _ in range(self._num_cols)
        ]
```
        This way, I can keep the parameters that ask for the 2d index as x and y without further confusion. 
## Overriding dunder methods to format Cell
- T enhance debugging, I added a `__format__` method to Maze and Cell
## Maze algorithm
- Used a recursive backtracking algorithm to construct maze
```py
    def _break_walls_r(self, col: int, row: int) -> None:
        current_cell: Cell = self._maze.get_cell(col, row)
        current_cell.visited = True

        # Directions to move in the maze
        directions = ["top", "right", "bottom", "left"]
        random.shuffle(directions)  # Shuffle directions to create a random maze

        for direction in directions:
            # Get the neighbor cell based on the direction
            neighbor_coords, opposite_direction = self._get_neighbor_coords(col, row, direction)
            neighbor_col, neighbor_row = neighbor_coords

            # Boundary check
            if 0 <= neighbor_row <= self._maze.num_rows and 0 <= neighbor_col <= self._maze.num_cols:
                neighbor = self._maze.get_cell(neighbor_col, neighbor_row, )

                # If the neighbor hasn't been visited, break the walls and recurse
                if neighbor and not neighbor.visited:
                    # Break the wall between current cell and neighbor
                    setattr(current_cell, f"has_{direction}_wall", False)
                    setattr(neighbor, f"has_{opposite_direction}_wall", False)

                    # Recursively call the function for the neighbor cell
                    self._break_walls_r(neighbor_col, neighbor_row)
            self._draw_cell(col, row)
```
## Unit testing
- Added unit test for `set_univisted_cells`
- Added a a decorator function to mock the starting of a window and any methods related to drawing on canvas. Uses the mock.patch context manager to generate mocks from certain methods. Selecting the correct methods sped up tests from > 10s to < 0.2s. Previously, the methods I was mocking was still simulating the creation of cells, just without drawing them to canvas. This new patch only mocks the instantiation of a Window object and any methods that reference `Window._draw_line`

# TODO:
- [x] Add tests for current algorithm 
- [x] Fix defect that does not draw exit properly