### PR TITLE
Feature: Refactor reset button functionality

### DIFF
--- a/src/maze.py
+++ b/src/maze.py
@@ -287,9 +287,11 @@ class MazeDrawer:
                     self._break_walls_r(neighbor_col, neighbor_row)
             self._draw_cell(col, row)
 
-    def draw_move(self, from_cell: Cell, to_cell: "Cell", undo=False) -> None:
+    def draw_move(self, from_cell: Cell, to_cell: "Cell", undo=False) -> int:
         """
         Draws a line connecting two cells on the canvas.
+        If undo is True, the line will backtrack
+        Returns id created from self._canvas.create_line to be able to delete it later
 
         Parameters
         ----------
@@ -317,7 +319,8 @@ class MazeDrawer:
             Point(center_x_source, center_y_source),
             Point(center_x_destination, center_y_destination),
         )
-        self._canvas.draw_line(line, fill_color=line_color)
+        line_id = self._canvas.draw_line(line, fill_color=line_color)
+        return line_id
 
 
 class MazeSolver:
@@ -351,6 +354,7 @@ class MazeSolver:
         Calls self._dfs_r from the first cell
         return self._dfs_r(0, 0)
         """
+        self.solution = set()
         return self._dfs_r(0, 0)
 
     def _dfs_r(self, col: int, row: int) -> bool:
@@ -390,14 +394,18 @@ class MazeSolver:
                     and not getattr(neighbor, f"has_{opposite_direction}_wall")
                 ):
                     # draw move to neighbor
-                    self._drawer.draw_move(current_cell, neighbor)
+                    line_id = self._drawer.draw_move(current_cell, neighbor)
+                    self.solution.add(line_id)
                     self._drawer._animate(path=True)
                     if self._dfs_r(neighbor_col, neighbor_row):
                         # if neighbor is last cell, return True
                         return True
                     else:
                         # if neighbor is not last cell, recursively backtrack
-                        self._drawer.draw_move(neighbor, current_cell, undo=True)
+                        line_id = self._drawer.draw_move(
+                            neighbor, current_cell, undo=True
+                        )
+                        self.solution.add(line_id)
                         self._drawer._animate(path=True)
 
                     self._dfs_r(neighbor_col, neighbor_row)

--- a/src/screen.py
+++ b/src/screen.py
@@ -90,6 +90,10 @@ class App(Frame):
         self.row_input.config(validate="key", validatecommand=(validate_int, "%P"))
         self.col_input.config(validate="key", validatecommand=(validate_int, "%P"))
 
+    @property
+    def root(self):
+        return self.__root
+
     def _enable_draw_button(self, event):
         """
         Validates that both entries have values before enabling draw button
@@ -98,10 +102,6 @@ class App(Frame):
             self.toggle_button_state("draw", True)
         else:
             self.toggle_button_state("draw", False)
-
-    @property
-    def root(self):
-        return self.__root
 
     def _create_widgets(self):
         """
@@ -126,6 +126,7 @@ class App(Frame):
 
     def _create_buttons(self):
         actions = ["draw", "solve", "reset"]
+
         for i, action in enumerate(actions):
             self.buttons[action] = Button(
                 self.control_frame,
@@ -135,9 +136,7 @@ class App(Frame):
             )
 
             self.buttons[action].grid(row=2, column=i)
-
-        self.toggle_button_state("draw", False)
-        self.toggle_button_state("solve", False)
+            self.toggle_button_state(action, False)
 
     def start(self) -> None:
         self.__root.mainloop()
@@ -344,16 +343,15 @@ class CanvasFrame(Frame):
             showerror(title="Error", message="Must draw maze before solving it")
         self.set_state(CanvasState.IDLE)
         self.toggle_button_state("draw", True)
+        self.toggle_button_state("reset", True)
 
     def reset_maze(self):
         if hasattr(self, "maze_solver"):
             print(self.maze_solver.solution)
             for item in self.maze_solver.solution:
                 self.canvas.delete(item)
-            # self.canvas.delete(self.solution_id)
+
             self.__window.redraw()
-            self.maze = None
-            self.drawer = None
             self.set_state(CanvasState.IDLE)
             self.toggle_button_state("solve", True)
             self.toggle_button_state("draw", True)

--- a/src/screen.py
+++ b/src/screen.py
@@ -301,8 +301,7 @@ class CanvasFrame(Frame):
         try:
             num_cols, num_rows = self._validate_input()
             padding_x, padding_y = self._calculate_padding(num_cols, num_rows)
-            if self.maze:
-                self.reset_maze()
+            self._clear_canvas()
 
             self.toggle_button_state("draw", False)
             self.toggle_button_state("solve", False)
@@ -356,7 +355,7 @@ class CanvasFrame(Frame):
             self.maze = None
             self.drawer = None
             self.set_state(CanvasState.IDLE)
-            self.toggle_button_state("solve", False)
+            self.toggle_button_state("solve", True)
             self.toggle_button_state("draw", True)
 
     def _bind_return(self, func: Callable):


### PR DESCRIPTION
# Feature - Refactor reset button
### Purpose
The reset button currently clears the canvas, but for a more accurate reset, the reset button should only clear the solved path from maze while keeping the existing unsolved maze on screen. If the user wants to draw a new maze, they do not need to reset the canvas. By having the reset only clear the solved path, this provides a more intuitive user experience. 

### What was done
Reset solved maze while maintaining maze structure on screen
- [x] save lines that are drawn as a move as state or data attribute
- [x] put constants at top of file
- [x] update names of certain variables for clearer intentions
- [x] verify unit tests still run OK
- [x] Update reset_maze method to only remove lines drawn by MazeSolver from canvas
